### PR TITLE
Minor fixes to standards docs

### DIFF
--- a/CREATE_A_ROLE.md
+++ b/CREATE_A_ROLE.md
@@ -3,8 +3,8 @@ A basic guide for how to create a new role in oasis-roles
 Setup environment
 =================
 
-The following Python tools should be isntalled in either a virtualenv or in your system or elsewise
-should be on your system path
+The following Python tools should be installed in either a virtualenv or in your system or elsewise
+should be on your system path:
 
 * ansible
 * ansible-lint

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Ansible Best Practices
 ** When a single large role is doing many complicated tasks and cannot easily be broken into multiple roles,
    but the process proceeds in multiple related stages
 * Avoid calling the `package` module iteratively with the `{{ item }}` argument, as this is impressively
-  more slow than calling it with the line `name: "{{ foo_packages | join(',') }}"`. The same can go for
-  many other packages that can be given an entire list of items all at once.
+  more slow than calling it with the line `name: "{{ foo_packages }}"`.  The same can go for many other
+  modules that can be given an entire list of items all at once.
 
 Vars vs Defaults
 ----------------


### PR DESCRIPTION
- Renamed CREATE_A_ROLL to CREATE_A_ROLE
- Fix typo in CREATE_A_ROL{E,L}
- Updated README note about passing lists to `package` et al.,
  since ansible 2.0 all packaging modules (that I'm aware of) can take
  a list directly.